### PR TITLE
hidde item label

### DIFF
--- a/src/app/components/footer/footer.component.html
+++ b/src/app/components/footer/footer.component.html
@@ -6,7 +6,7 @@
        <a [href]="item.route">
       <i [class]="item.icon"></i>
     </a>
-    <h4 class="text-md font-medium">{{item.label}}</h4>
+    <h4 class="text-md font-medium hidden">{{item.label}}</h4>
       </div>
     }
   </div>


### PR DESCRIPTION
se le ha agregado la clase hidden al item label del Footer, en casi todas y por regla general si vas a poner el logo de la rrss en los social links, no se pone el nombre de la redsocial porque el logo es representativo, no es necesario y como se podía ver antes la red de X se veía como repetida dando la apariencia de ser un bug.
Before
<img width="935" height="117" alt="image" src="https://github.com/user-attachments/assets/bf7f13a0-0a06-4de1-841c-939f6d74f092" />
After:
<img width="930" height="117" alt="Captura de pantalla 2025-07-26 153735" src="https://github.com/user-attachments/assets/d9c3b018-9824-406c-8a4f-f59a597b1521" />